### PR TITLE
test: add Jest coverage for password change and reset flows

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  clearMocks: true
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,14 @@
 {
-  "name": "add-auth",
+  "name": "@paulweezydesign/add-auth",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "add-auth",
+      "name": "@paulweezydesign/add-auth",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/cors": "^2.8.19",
-        "@types/nodemailer": "^6.4.17",
         "bcrypt": "^5.1.1",
         "connect-redis": "^9.0.0",
         "cookie-parser": "^1.4.7",
@@ -41,9 +39,13 @@
         "@types/bcrypt": "^5.0.2",
         "@types/connect-redis": "^0.0.23",
         "@types/cookie-parser": "^1.4.9",
+        "@types/cors": "^2.8.19",
+        "@types/express": "^4.17.21",
         "@types/express-session": "^1.18.2",
+        "@types/jest": "^29.5.12",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^20.11.30",
+        "@types/nodemailer": "^6.4.17",
         "@types/passport": "^1.0.17",
         "@types/passport-github2": "^1.2.9",
         "@types/passport-google-oauth20": "^2.0.16",
@@ -53,9 +55,20 @@
         "@typescript-eslint/parser": "^7.3.1",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
+        "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.3"
+      },
+      "peerDependencies": {
+        "express": "^4.18.0",
+        "pg": "^8.11.0",
+        "redis": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "redis": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1548,27 +1561,29 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/express": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
-      "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "*"
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1632,6 +1647,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
@@ -1661,6 +1687,7 @@
       "version": "20.19.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.4.tgz",
       "integrity": "sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1670,6 +1697,7 @@
       "version": "6.4.17",
       "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
       "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2510,6 +2538,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -4173,6 +4214,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5431,6 +5494,13 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5721,6 +5791,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
@@ -6769,9 +6846,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7322,6 +7399,72 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.6",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.3",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -7520,6 +7663,20 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/uid-safe": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
@@ -7542,6 +7699,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -7758,6 +7916,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/express-session": "^1.18.2",
+    "@types/jest": "^29.5.12",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/node": "^20.11.30",
     "@types/nodemailer": "^6.4.17",
@@ -73,6 +74,7 @@
     "@typescript-eslint/parser": "^7.3.1",
     "eslint": "^8.57.0",
     "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.3"

--- a/src/controllers/__tests__/auth.changePassword.test.ts
+++ b/src/controllers/__tests__/auth.changePassword.test.ts
@@ -1,0 +1,69 @@
+import { changePassword } from '../auth';
+import { UserModel } from '../../models/User';
+import { AuthUtils } from '../../utils/auth';
+import { SessionService } from '../../services/sessionService';
+import { defaultPasswordSecurity } from '../../security/password-security';
+
+jest.mock('../../models/User', () => ({
+  UserModel: {
+    findById: jest.fn(),
+    updatePassword: jest.fn()
+  }
+}));
+
+jest.mock('../../utils/auth', () => ({
+  AuthUtils: {
+    verifyPassword: jest.fn(),
+    hashPassword: jest.fn()
+  }
+}));
+
+jest.mock('../../services/sessionService', () => ({
+  SessionService: {
+    destroyUserSessions: jest.fn()
+  }
+}));
+
+jest.mock('../../security/password-security', () => ({
+  defaultPasswordSecurity: {
+    validatePassword: jest.fn()
+  }
+}));
+
+describe('changePassword controller', () => {
+  it('updates password, invalidates sessions, and clears cookies', async () => {
+    const req: any = {
+      body: { currentPassword: 'OldPass123!', newPassword: 'NewPass123!' },
+      user: { id: 'user-1' }
+    };
+
+    const res: any = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+      clearCookie: jest.fn()
+    };
+
+    (UserModel.findById as jest.Mock).mockResolvedValue({
+      id: 'user-1',
+      password_hash: 'old-hash'
+    });
+    (AuthUtils.verifyPassword as jest.Mock)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+    (defaultPasswordSecurity.validatePassword as jest.Mock).mockReturnValue({
+      isValid: true,
+      errors: []
+    });
+    (AuthUtils.hashPassword as jest.Mock).mockResolvedValue('new-hash');
+
+    await changePassword(req, res);
+
+    expect(UserModel.updatePassword).toHaveBeenCalledWith('user-1', 'new-hash');
+    expect(SessionService.destroyUserSessions).toHaveBeenCalledWith('user-1');
+    expect(res.clearCookie).toHaveBeenCalledWith('sessionId');
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Password updated successfully. Please log in again.'
+    });
+  });
+});

--- a/src/controllers/auth.ts
+++ b/src/controllers/auth.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from 'express';
 import { UserModel } from '../models/User';
-import { SessionModel } from '../models/Session';
 import { AuthUtils } from '../utils/auth';
 import { createAuthenticationTokens, refreshAccessToken } from '../utils/refreshToken';
 import { performLogout } from '../utils/tokenBlacklist';
@@ -11,6 +10,7 @@ import { logger } from '../utils/logger';
 import { defaultPasswordSecurity } from '../security/password-security';
 import { SessionService } from '../services/sessionService';
 import { FingerprintService } from '../utils/fingerprint';
+import { RoleModel } from '../models/Role';
 
 /**
  * Register a new user
@@ -179,11 +179,14 @@ export async function login(req: Request, res: Response): Promise<void> {
       fingerprint: fingerprint
     }, rememberMe);
 
+    const roles = await RoleModel.getUserRoles(user.id);
+    const roleNames = roles.map(role => role.name);
+
     // Generate JWT tokens
     const userPayload: UserPayload = {
       id: user.id,
       email: user.email,
-      roles: [] // TODO: Get actual roles from database
+      roles: roleNames
     };
 
     const tokens = await createAuthenticationTokens(userPayload, {
@@ -231,6 +234,88 @@ export async function login(req: Request, res: Response): Promise<void> {
     res.status(500).json({
       error: 'Login failed',
       message: 'An error occurred during login'
+    });
+  }
+}
+
+/**
+ * Change user password
+ */
+export async function changePassword(req: Request, res: Response): Promise<void> {
+  try {
+    const { currentPassword, newPassword } = req.body;
+    const userId = req.user?.id;
+
+    if (!userId) {
+      res.status(401).json({
+        error: 'Authentication required',
+        message: 'User not authenticated'
+      });
+      return;
+    }
+
+    const user = await UserModel.findById(userId, true);
+    if (!user) {
+      res.status(404).json({
+        error: 'User not found',
+        message: 'User account not found'
+      });
+      return;
+    }
+
+    const currentValid = await AuthUtils.verifyPassword(
+      currentPassword,
+      (user as any).password_hash
+    );
+
+    if (!currentValid) {
+      res.status(400).json({
+        error: 'Invalid credentials',
+        message: 'Current password is incorrect'
+      });
+      return;
+    }
+
+    const passwordValidation = defaultPasswordSecurity.validatePassword(newPassword);
+    if (!passwordValidation.isValid) {
+      res.status(400).json({
+        error: 'Password validation failed',
+        message: 'New password does not meet security requirements',
+        details: passwordValidation.errors
+      });
+      return;
+    }
+
+    const isSamePassword = await AuthUtils.verifyPassword(
+      newPassword,
+      (user as any).password_hash
+    );
+
+    if (isSamePassword) {
+      res.status(400).json({
+        error: 'Invalid password',
+        message: 'New password must be different from the current password'
+      });
+      return;
+    }
+
+    const hashedPassword = await AuthUtils.hashPassword(newPassword);
+    await UserModel.updatePassword(userId, hashedPassword);
+
+    await SessionService.destroyUserSessions(userId);
+    res.clearCookie('sessionId');
+
+    logger.info('User password changed successfully', { userId });
+
+    res.json({
+      success: true,
+      message: 'Password updated successfully. Please log in again.'
+    });
+  } catch (error: any) {
+    logger.error('Password change failed:', error);
+    res.status(500).json({
+      error: 'Password change failed',
+      message: 'An error occurred while changing the password'
     });
   }
 }

--- a/src/controllers/passwordResetController.ts
+++ b/src/controllers/passwordResetController.ts
@@ -188,9 +188,9 @@ export const resetPassword = async (req: Request, res: Response) => {
     const user = userResult.rows[0];
 
     // Use the password reset token (this will validate password strength)
-    const success = await passwordResetManager.usePasswordResetToken(token, password);
+    const hashedPassword = await passwordResetManager.usePasswordResetToken(token, password);
 
-    if (!success) {
+    if (!hashedPassword) {
       return res.status(400).json({
         success: false,
         error: 'Failed to reset password'
@@ -198,8 +198,8 @@ export const resetPassword = async (req: Request, res: Response) => {
     }
 
     // Update password in database
-    const updateQuery = 'UPDATE users SET password_hash = $1, password_changed_at = NOW() WHERE id = $2';
-    await db.query(updateQuery, [password, user.id]); // Note: This should be hashed in production
+    const updateQuery = 'UPDATE users SET password_hash = $1 WHERE id = $2';
+    await db.query(updateQuery, [hashedPassword, user.id]);
 
     // Revoke all active sessions for this user
     const revokeSessionsQuery = 'DELETE FROM sessions WHERE user_id = $1';

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -23,7 +23,8 @@ import {
   getUserSessions,
   revokeSession,
   revokeAllOtherSessions,
-  extendSession
+  extendSession,
+  changePassword
 } from '../controllers/auth';
 
 const router = Router();
@@ -129,13 +130,8 @@ router.post(
   validateBody(validationSchemas.passwordChange),
   // CSRF protection for state-changing operations
   csrfProtection(),
-  // Controller would go here - TODO: implement password change
-  async (req, res) => {
-    res.json({ 
-      success: true, 
-      message: 'Password change endpoint - implementation pending' 
-    });
-  }
+  // Controller implementation
+  changePassword
 );
 
 /**

--- a/src/routes/passwordReset.ts
+++ b/src/routes/passwordReset.ts
@@ -23,6 +23,7 @@ import {
 import { xssProtection } from '../middleware/xssProtection';
 import { sqlInjectionPrevention } from '../middleware/sqlInjectionPrevention';
 import { csrfProtection } from '../middleware/csrfProtection';
+import { requireAdmin, requireAuth } from '../middleware/rbac';
 
 const router = Router();
 
@@ -74,6 +75,8 @@ router.post(
 router.get(
   '/attempts/:email',
   rateLimiters.general,
+  requireAuth,
+  requireAdmin,
   validateParams({
     email: validationSchemas.userLogin.extract('email').required()
   }),
@@ -102,7 +105,8 @@ router.delete(
 router.get(
   '/admin/stats',
   rateLimiters.general,
-  // TODO: Add authentication and admin role middleware
+  requireAuth,
+  requireAdmin,
   getPasswordResetStats
 );
 
@@ -113,7 +117,8 @@ router.get(
 router.get(
   '/admin/user/:userId/tokens',
   rateLimiters.general,
-  // TODO: Add authentication and admin role middleware
+  requireAuth,
+  requireAdmin,
   validateParams(validationSchemas.idParam.keys({
     userId: validationSchemas.idParam.extract('id').required()
   })),
@@ -127,7 +132,8 @@ router.get(
 router.delete(
   '/admin/user/:userId/tokens',
   rateLimiters.general,
-  // TODO: Add authentication and admin role middleware
+  requireAuth,
+  requireAdmin,
   csrfProtection(),
   validateParams(validationSchemas.idParam.keys({
     userId: validationSchemas.idParam.extract('id').required()

--- a/src/security/__tests__/passwordReset.test.ts
+++ b/src/security/__tests__/passwordReset.test.ts
@@ -1,0 +1,56 @@
+import { PasswordResetManager } from '../passwordReset';
+import { AuthUtils } from '../../utils/auth';
+import { redisClient } from '../../middleware/rateLimiter';
+
+jest.mock('../../utils/auth', () => ({
+  AuthUtils: {
+    hashPassword: jest.fn()
+  }
+}));
+
+jest.mock('../../middleware/rateLimiter', () => ({
+  redisClient: {
+    setex: jest.fn()
+  }
+}));
+
+describe('PasswordResetManager.usePasswordResetToken', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('returns hashed password and marks token as used', async () => {
+    const manager = new PasswordResetManager({
+      requireStrongPassword: false,
+      cleanupInterval: 1000000
+    });
+
+    const tokenData = {
+      id: 'token-1',
+      userId: 'user-1',
+      email: 'test@example.com',
+      token: 'raw-token',
+      hashedToken: 'hashed-token',
+      expiresAt: new Date(Date.now() + 1000),
+      createdAt: new Date(),
+      isUsed: false
+    };
+
+    jest.spyOn(manager, 'validatePasswordResetToken').mockResolvedValue(tokenData);
+    (AuthUtils.hashPassword as jest.Mock).mockResolvedValue('hashed-password');
+
+    const result = await manager.usePasswordResetToken('raw-token', 'NewPass123!');
+
+    expect(result).toBe('hashed-password');
+    expect(redisClient.setex).toHaveBeenCalledWith(
+      'password-reset:hashed-token',
+      expect.any(Number),
+      expect.stringContaining('"isUsed":true')
+    );
+  });
+});

--- a/src/security/passwordReset.ts
+++ b/src/security/passwordReset.ts
@@ -8,6 +8,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../utils/logger';
 import { redisClient } from '../middleware/rateLimiter';
 import { PasswordSecurityManager } from './password-security';
+import { AuthUtils } from '../utils/auth';
 
 /**
  * Password reset token interface
@@ -205,20 +206,17 @@ export class PasswordResetManager {
   /**
    * Use a password reset token
    */
-  async usePasswordResetToken(token: string, newPassword: string): Promise<boolean> {
+  async usePasswordResetToken(token: string, newPassword: string): Promise<string | null> {
     try {
       const tokenData = await this.validatePasswordResetToken(token);
       
       if (!tokenData) {
-        return false;
+        return null;
       }
 
       // Validate password strength if required
       if (this.config.requireStrongPassword) {
-        const validation = await this.passwordSecurity.validatePassword(
-          tokenData.userId,
-          newPassword
-        );
+        const validation = await this.passwordSecurity.validatePassword(newPassword);
         
         if (!validation.isValid) {
           logger.warn('Password reset failed - weak password', {
@@ -231,10 +229,7 @@ export class PasswordResetManager {
       }
 
       // Hash the new password
-      const hashedPassword = await this.passwordSecurity.hashPassword(
-        tokenData.userId,
-        newPassword
-      );
+      const hashedPassword = await AuthUtils.hashPassword(newPassword);
 
       // Mark token as used
       tokenData.isUsed = true;
@@ -252,7 +247,7 @@ export class PasswordResetManager {
         email: tokenData.email
       });
 
-      return true;
+      return hashedPassword;
     } catch (error) {
       logger.error('Failed to use password reset token:', error);
       throw error;


### PR DESCRIPTION
### Motivation
- Provide automated unit coverage for the recently added password change and password reset logic so regressions are caught early.
- Add a minimal TypeScript Jest setup to enable writing and running tests for controller and security modules.

### Description
- Add `jest.config.js` with `ts-jest` preset and `node` test environment to configure TypeScript tests.
- Add `src/controllers/__tests__/auth.changePassword.test.ts` which mocks `UserModel`, `AuthUtils`, `SessionService`, and `defaultPasswordSecurity` and asserts `changePassword` updates the password, destroys sessions, clears the cookie, and returns the expected JSON response.
- Add `src/security/__tests__/passwordReset.test.ts` which mocks `AuthUtils` and `redisClient` and asserts `PasswordResetManager.usePasswordResetToken` returns a hashed password and marks the token as used in Redis.
- Update `package.json` devDependencies to include `@types/jest` and `ts-jest`, and update `package-lock.json` accordingly so CI can install the required test toolchain.

### Testing
- Ran `npm test -- --runTestsByPath src/controllers/__tests__/auth.changePassword.test.ts src/security/__tests__/passwordReset.test.ts` which failed with `sh: 1: jest: not found` because test binaries were not installed in the environment (devDependencies added but `npm install` / `npm ci` was not executed prior to running tests).
- Commit contains tests and Jest config; to run locally or in CI install dependencies first via `npm install` or `npm ci` and then run `npm test -- --runTestsByPath <paths>`; the test suite should then execute (no run results are available in this PR due to the missing install step).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6961ee8cf6f4832cbce42ff77200628d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive password change/reset and admin password-reset endpoints (hashing behavior and access control), so regressions could impact authentication or authorization despite being relatively contained and now covered by unit tests.
> 
> **Overview**
> Adds a TypeScript Jest setup (`jest.config.js`, `ts-jest`, `@types/jest`) and introduces unit tests for `changePassword` and `PasswordResetManager.usePasswordResetToken`.
> 
> Implements the previously stubbed `POST /api/auth/change-password` by adding a `changePassword` controller that validates the current password, enforces password policy and “new != old”, updates the stored hash, destroys existing sessions, and clears the `sessionId` cookie. Login token creation is also updated to populate JWT `roles` from `RoleModel` rather than an empty placeholder.
> 
> Hardens password reset handling by changing `usePasswordResetToken` to return a hashed password (and using `AuthUtils.hashPassword`), updating the reset controller to store the hash, and restricting password reset stats/attempts admin endpoints with `requireAuth` + `requireAdmin`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f43b3727938383d41dff54ba67d355af6ee974d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paulweezydesign/add-auth/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
