### PR TITLE
Set up development environment + verify end-to-end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -445,11 +445,21 @@ npm run dev   # Dev server with hot-reload (uses ts-node-dev --transpile-only)
 
 The server listens on port 3000. See `package.json` for all available scripts.
 
+### Frontend example apps
+
+`example-apps/` contains demo clients that talk to the API on port 3000 (each has its own `package.json`; run `npm install` then `npm run dev` inside the app):
+
+- `react-auth-demo` (Vite, port 5173) — good for a quick end-to-end UI check of register/login/dashboard.
+- `nextjs-auth-demo` (Next.js, port 3001).
+- `vanilla-auth-demo` — static HTML/JS (open `index.html` or serve the folder).
+
+The API CORS allowlist comes from `FRONTEND_URL` (comma-separated). Include the demo origins (e.g. `http://localhost:5173`, `http://localhost:3001`) so browser calls with credentials succeed.
+
 ### Key caveats
 
 - **`DB_SSL` env var**: Zod's `z.coerce.boolean()` treats the string `"false"` as truthy. Either leave `DB_SSL` unset (defaults to `false`) or set it to an empty string. Do NOT set `DB_SSL=false`.
 - **TypeScript build (`npm run build`)**: The codebase has many pre-existing type errors. The dev server works because it uses `--transpile-only`. A clean `tsc` build will fail.
 - **ESLint config**: The `.eslintrc.json` extends value must be `plugin:@typescript-eslint/recommended` (not `@typescript-eslint/recommended`).
-- **Tests**: No test files exist yet. Run `npm test -- --passWithNoTests` to avoid a non-zero exit code.
+- **Tests**: A few Jest suites exist under `src/**/__tests__/` (e.g. `passwordReset.test.ts`, `auth.changePassword.test.ts`). Some of these currently fail due to pre-existing test/code issues, not environment problems. `npm test` runs them; keep `--passWithNoTests` when running a filtered subset that may match nothing.
 - **Database migrations**: Run `npx ts-node src/database/migrate.ts migrate` (the `npm run migrate` script does not pass the `migrate` subcommand argument).
-- **CSRF tokens**: All mutating API endpoints require a CSRF token. Fetch one from `GET /api/auth/csrf-token` first, then pass it via the `X-CSRF-Token` header with the session cookie.
+- **CSRF tokens**: Every `/api/auth/*` POST (including `register` and `login`, not just later mutating calls) requires a CSRF token. Fetch one from `GET /api/auth/csrf-token` using a cookie jar, then send the returned token via the `X-CSRF-Token` header together with the same session cookie on subsequent requests.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up a fresh development environment for the `@paulweezydesign/add-auth` authentication API and verified it works end to end (API + database + Redis + a frontend demo client).

The only code change here is a small docs update to the `## Cursor Cloud specific instructions` in `AGENTS.md`. No application code was modified.

## What was installed / configured

- System services: PostgreSQL 16 and Redis (started via `pg_ctlcluster` / `redis-server`).
- Node dependencies for the root library and the `example-apps/` demo clients.
- Local `.env` (gitignored) matching `.env.example`, with `DB_SSL` intentionally left unset per the known Zod coercion caveat, and `FRONTEND_URL` extended to include the demo origins.
- Ran migrations: `npx ts-node src/database/migrate.ts migrate` (all 6 migrations applied).

## Verification

| Service | Lint | Test | Run |
|---|---|---|---|
| Auth API (Express, port 3000) | `npm run lint` (runs; 44 pre-existing errors) | `npm test` (runs; 2 suites, 1 pre-existing failure) | `npm run dev` → `/health` reports `database: connected`, `redis: connected` |
| React demo (`example-apps/react-auth-demo`, Vite port 5173) | n/a | n/a | `npm run dev` → renders, "API: online" |

Hello-world task (core functionality): registered a new user and logged in.

- API: `GET /api/auth/csrf-token` → `POST /api/auth/register` → `POST /api/auth/login` → authenticated `GET /api/auth/me` all succeed; users persist in PostgreSQL and sessions are created.
- UI: registered `demo2026@example.com` through the React demo and landed on the logged-in Dashboard.

[react_demo_register_login_e2e.mp4](https://cursor.com/agents/bc-54cac3e4-9baf-4c38-afef-2e476c6a570b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_demo_register_login_e2e.mp4)

[React demo dashboard after registration](https://cursor.com/agents/bc-54cac3e4-9baf-4c38-afef-2e476c6a570b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freact_demo_dashboard.webp)

## AGENTS.md updates

- Corrected the outdated "no test files exist" note (Jest suites now exist under `src/**/__tests__/`, some pre-existing failures).
- Added a short "Frontend example apps" subsection (ports + `FRONTEND_URL` CORS note).
- Clarified that `register`/`login` also require a CSRF token, not just later mutating calls.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54cac3e4-9baf-4c38-afef-2e476c6a570b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54cac3e4-9baf-4c38-afef-2e476c6a570b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

