### PR TITLE
chore: gitignore dump.rdb and fix merged Thumbs.db entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,8 @@ public
 .Spotlight-V100
 .Trashes
 ehthumbs.db
-Thumbs.dbdump.rdb
+Thumbs.db
+
+# Redis runtime dump
+dump.rdb
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small `.gitignore` cleanup discovered during environment setup.

- The last line of `.gitignore` was a corrupted, merged entry `Thumbs.dbdump.rdb` (two patterns concatenated with no newline), so neither `Thumbs.db` nor `dump.rdb` was actually being ignored.
- Split it back into a proper `Thumbs.db` entry and added a dedicated `dump.rdb` ignore (Redis writes this RDB snapshot at runtime when Redis is running locally).

## Verification

`git check-ignore dump.rdb` now returns `dump.rdb` (exit 0), and the file no longer appears as untracked in `git status`.

No application code changed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54cac3e4-9baf-4c38-afef-2e476c6a570b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54cac3e4-9baf-4c38-afef-2e476c6a570b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

